### PR TITLE
Fix password analyzer scoring

### DIFF
--- a/password-analyzer/src/password_analyzer.py
+++ b/password-analyzer/src/password_analyzer.py
@@ -208,7 +208,10 @@ def analyze_password(password):
     
     # Calculate final score using weighted average
     final_score = (
-        (min(100, entropy * 4) * ENTROPY_WEIGHT) +
+        # Scale entropy down instead of up so weak passwords don't
+        # automatically receive a high score. This prevents short,
+        # simple passwords from appearing "Strong".
+        (min(100, entropy / 4) * ENTROPY_WEIGHT) +
         (complexity_score * COMPLEXITY_WEIGHT) +
         (pattern_score * PATTERN_WEIGHT)
     )


### PR DESCRIPTION
## Summary
- reduce entropy impact in password analyzer scoring

## Testing
- `python3 tests/test_analyzer.py > /tmp/test_output.txt && tail -n 20 /tmp/test_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_684039f82fac8321b7111014729fcefd